### PR TITLE
Fix pip install when metaflow is not preinstalled

### DIFF
--- a/daps_utils/VERSION
+++ b/daps_utils/VERSION
@@ -1,1 +1,1 @@
-21.02.08.39_actconf
+21.03.16.53_fix_pip_install

--- a/daps_utils/__init__.py
+++ b/daps_utils/__init__.py
@@ -1,13 +1,17 @@
+import os
+
 from .__initplus__ import __basedir__, load_config, load_current_version
 
-try:
-    from .breadcrumbs import drop_breadcrumb as talk_to_luigi
-    from .tasks import (MetaflowTask, CurateTask, ForceableTask,
-                        DapsTaskMixin, DapsRootTask)
-    from .flow import DapsFlowMixin
-    config = load_config()
-except ModuleNotFoundError as exc:  # For integration with setup.py
-    print(exc)
-    pass
-
 __version__ = load_current_version()
+
+if "IN_SETUP" not in os.environ:
+    try:
+        from .breadcrumbs import drop_breadcrumb as talk_to_luigi
+        from .tasks import (MetaflowTask, CurateTask, ForceableTask,
+                            DapsTaskMixin, DapsRootTask)
+        from .flow import DapsFlowMixin
+        config = load_config()
+    except ModuleNotFoundError as exc:  # For integration with setup.py
+        print(exc)
+        pass
+

--- a/daps_utils/__init__.py
+++ b/daps_utils/__init__.py
@@ -5,13 +5,9 @@ from .__initplus__ import __basedir__, load_config, load_current_version
 __version__ = load_current_version()
 
 if "IN_SETUP" not in os.environ:
-    try:
-        from .breadcrumbs import drop_breadcrumb as talk_to_luigi
-        from .tasks import (MetaflowTask, CurateTask, ForceableTask,
-                            DapsTaskMixin, DapsRootTask)
-        from .flow import DapsFlowMixin
-        config = load_config()
-    except ModuleNotFoundError as exc:  # For integration with setup.py
-        print(exc)
-        pass
+    from .breadcrumbs import drop_breadcrumb as talk_to_luigi
+    from .tasks import (MetaflowTask, CurateTask, ForceableTask,
+                        DapsTaskMixin, DapsRootTask)
+    from .flow import DapsFlowMixin
+    config = load_config()
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
+import os
 from setuptools import setup
 from setuptools import find_namespace_packages
-from daps_utils import __version__, __basedir__
+
+os.environ["IN_SETUP"] = "1"  # noqa: E402
+
+from daps_utils import __version__, __basedir__  # noqa: E402
+
 
 version = ''.join(v for v in __version__ if (v.isnumeric() or v == '.'))
 


### PR DESCRIPTION
Closes #53

In a virtualenv without `metaflow` installed:
- Doesn't work: `pip install git+https://github.com/nestauk/daps_utils@dev`
- Does work: `pip install git+https://github.com/nestauk/daps_utils@53_fix_pip_install`
