### PR TITLE
[68] Updated metaflow version to be >=

### DIFF
--- a/daps_utils/VERSION
+++ b/daps_utils/VERSION
@@ -1,1 +1,1 @@
-21.05.10.65_reqs
+21.05.10.68_metaflow_version

--- a/daps_utils/requirements.txt
+++ b/daps_utils/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.16.26
 pytest>=5.4.3
-metaflow==2.0.5
+metaflow>=2.0.5
 luigi==3.0.2
 docker==4.3.1
 PyYAML==5.4.0


### PR DESCRIPTION
Closes #68

Updates `metaflow` version to be `>=` to current version, which allows me to work on a fork of the `metaflow` master branch (adding feature nestauk/metaflow#1)