### PR TITLE
`stale_breadcrumb` feature

### DIFF
--- a/daps_utils/VERSION
+++ b/daps_utils/VERSION
@@ -1,1 +1,1 @@
-21.08.18.103_batch_db
+21.08.24.101_stale_breadcrumbs

--- a/daps_utils/tasks.py
+++ b/daps_utils/tasks.py
@@ -31,15 +31,17 @@ CALLER_PKG = get_main_caller_pkg(inspect.currentframe())
 
 def import_pkg(daps_pkg):
     pkg = import_module(daps_pkg)
-    for attr in ('config', '__basedir__', '__version__'):
+    for attr in ("config", "__basedir__", "__version__"):
         assert_hasattr(pkg, attr, daps_pkg)
     return pkg
 
 
 def assert_hasattr(pkg, attr, pkg_name):
     if not hasattr(pkg, attr):
-        raise AttributeError(f"{pkg_name} is expected to have attribute '{attr}'. "
-                             "Have you run 'metaflowtask-init' from your package root?")
+        raise AttributeError(
+            f"{pkg_name} is expected to have attribute '{attr}'. "
+            "Have you run 'metaflowtask-init' from your package root?"
+        )
 
 
 def toggle_force_to_false(func):
@@ -50,6 +52,7 @@ def toggle_force_to_false(func):
     def wrapper(self, *args, **kwargs):
         self.force = False
         return func(self, *args, **kwargs)
+
     return wrapper
 
 
@@ -65,8 +68,10 @@ def toggle_exists(output_func):
             # "Unpatch" Target.exists() to it's original form
             else:
                 out.exists = lambda *args, **kwargs: (
-                    out.__class__.exists(out, *args, **kwargs))
+                    out.__class__.exists(out, *args, **kwargs)
+                )
         return outputs
+
     return wrapper
 
 
@@ -78,11 +83,12 @@ class DapsTaskMixinBase:
     The `db_name` parameter is a standard we have long settled with,
     and is an unnecessary source of repetition.
     """
+
     @property
     def db_name(self):
         if "pytest" in sys.modules:  # True if running from pytest
-            return 'test'
-        return 'dev' if self.test else 'production'
+            return "test"
+        return "dev" if self.test else "production"
 
 
 class DapsRootTask(luigi.WrapperTask, DapsTaskMixinBase):
@@ -101,6 +107,7 @@ class DapsRootTask(luigi.WrapperTask, DapsTaskMixinBase):
     `not production` is clunky and so the `test` property exists for this
     purpose.
     """
+
     production = luigi.BoolParameter(default=False)
 
     @property
@@ -116,6 +123,7 @@ class DapsTaskMixin(DapsTaskMixinBase):
     - A `test` luigi.Parameter by default
     - A `@property` called `production` which returns to opposite of `test`
     """
+
     test = luigi.BoolParameter()
 
     @property
@@ -126,10 +134,11 @@ class DapsTaskMixin(DapsTaskMixinBase):
 
 class ForceableTask(luigi.Task):
     """A luigi task which can be forceably rerun"""
+
     force = luigi.BoolParameter(significant=False, default=False)
     force_upstream = luigi.BoolParameter(significant=False, default=False)
 
-    def __init__(self,  *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Force children to be rerun
         if self.force_upstream:
@@ -150,9 +159,11 @@ class ForceableTask(luigi.Task):
 
 class MetaflowTask(ForceableTask):
     """Run metaflow Flows in Docker"""
+
     flow_path = luigi.Parameter()
-    flow_tag = luigi.ChoiceParameter(choices=["dev", "production"],
-                                     var_type=str, default="dev")
+    flow_tag = luigi.ChoiceParameter(
+        choices=["dev", "production"], var_type=str, default="dev"
+    )
     rebuild_base = luigi.BoolParameter(default=False)
     rebuild_flow = luigi.BoolParameter(default=True)
     flow_kwargs = luigi.DictParameter(default={})
@@ -160,11 +171,12 @@ class MetaflowTask(ForceableTask):
     container_kwargs = luigi.DictParameter(default={})
     requires_task = luigi.TaskParameter(default=S3PathTask)
     requires_task_kwargs = luigi.DictParameter(default={})
+    stale_breadcrumb = luigi.Parameter(default=None)
 
     @property
     def s3path(self):
         metaflow_config = get_metaflow_config()
-        return metaflow_config['METAFLOW_DATASTORE_SYSROOT_S3']
+        return metaflow_config["METAFLOW_DATASTORE_SYSROOT_S3"]
 
     def requires(self):
         if self.requires_task is S3PathTask:
@@ -172,24 +184,34 @@ class MetaflowTask(ForceableTask):
         return self.requires_task(**self.requires_task_kwargs)
 
     def run(self):
-        if 'tag' in self.flow_kwargs:
-            raise KeyError('"tag" argument should not be specified in "flow_kwargs". '
-                           'Use "flow_tag" to specify this value')
-        logs, tag = build_and_run_image(flow_path=self.flow_path,
-                                        rebuild_base=self.rebuild_base,
-                                        rebuild_flow=self.rebuild_flow,
-                                        pkg=CALLER_PKG,
-                                        flow_kwargs={'tag': self.flow_tag,
-                                                     **self.flow_kwargs},
-                                        preflow_kwargs=self.preflow_kwargs,
-                                        **self.container_kwargs)
+        if self.stale_breadcrumb is not None:
+            return
+        if "tag" in self.flow_kwargs:
+            raise KeyError(
+                '"tag" argument should not be specified in "flow_kwargs". '
+                'Use "flow_tag" to specify this value'
+            )
+        logs, tag = build_and_run_image(
+            flow_path=self.flow_path,
+            rebuild_base=self.rebuild_base,
+            rebuild_flow=self.rebuild_flow,
+            pkg=CALLER_PKG,
+            flow_kwargs={"tag": self.flow_tag, **self.flow_kwargs},
+            preflow_kwargs=self.preflow_kwargs,
+            **self.container_kwargs,
+        )
         breadcrumb = pickup_breadcrumb(logs)
-        out = self.output().open('w')
+        out = self.output().open("w")
         out.write(breadcrumb)
         out.close()
 
     def output(self):
-        return S3Target(f'{self.s3path}/{self.task_id}')
+        path = (
+            f"{self.s3path}/{self.task_id}"
+            if self.stale_breadcrumb is None
+            else self.stale_breadcrumb
+        )
+        return S3Target(path)
 
 
 class CurateTask(ForceableTask, DapsTaskMixin):
@@ -221,7 +243,13 @@ class CurateTask(ForceableTask, DapsTaskMixin):
         requires_task (luigi.Task): Any task that this task is dependent on.
         requires_task_kwargs (dict): Keyword arguments to pass to any dependent
                                      task, if applicable.
+        stale_breadcrumb (str): If not None, stale_breadcrumb should be the
+                                full s3 path (in the form
+                                s3://<bucket>/metaflow/MetaflowTask___*)
+                                to the breadcrumb file for a previously run
+                                MetaflowTask
     """
+
     orm = SqlAlchemyParameter()
     flow_path = luigi.Parameter()
     rebuild_base = luigi.BoolParameter(default=False)
@@ -231,27 +259,31 @@ class CurateTask(ForceableTask, DapsTaskMixin):
     container_kwargs = luigi.DictParameter(default={})
     requires_task = luigi.TaskParameter(default=S3PathTask)
     requires_task_kwargs = luigi.DictParameter(default={})
+    stale_breadcrumb = luigi.Parameter(default=None)
     low_memory = luigi.BoolParameter(default=True)
 
     def requires(self):
-        return MetaflowTask(flow_path=self.flow_path,
-                            flow_tag=self.db_name,
-                            rebuild_base=self.rebuild_base,
-                            rebuild_flow=self.rebuild_flow,
-                            flow_kwargs=self.flow_kwargs,
-                            preflow_kwargs=self.preflow_kwargs,
-                            container_kwargs=self.container_kwargs,
-                            requires_task=self.requires_task,
-                            requires_task_kwargs=self.requires_task_kwargs)
+        return MetaflowTask(
+            flow_path=self.flow_path,
+            flow_tag=self.db_name,
+            rebuild_base=self.rebuild_base,
+            rebuild_flow=self.rebuild_flow,
+            flow_kwargs=self.flow_kwargs,
+            preflow_kwargs=self.preflow_kwargs,
+            container_kwargs=self.container_kwargs,
+            requires_task=self.requires_task,
+            requires_task_kwargs=self.requires_task_kwargs,
+            stale_breadcrumb=self.stale_breadcrumb,
+        )
 
     def retrieve_data(self, s3path, file_prefix):
-        s3 = boto3.resource('s3')
+        s3 = boto3.resource("s3")
         S3REGEX = "s3://(.*)/(metaflow/data/.*)"
         bucket_name, prefix = re.findall(S3REGEX, s3path)[0]
         bucket = s3.Bucket(bucket_name)
         _prefix = f"{prefix}/{file_prefix}"
         for obj in bucket.objects.filter(Prefix=_prefix):
-            buffer = obj.get()['Body'].read().decode('utf-8')
+            buffer = obj.get()["Body"].read().decode("utf-8")
             yield json.loads(buffer)
 
     @abc.abstractclassmethod
@@ -270,11 +302,10 @@ class CurateTask(ForceableTask, DapsTaskMixin):
             Base = get_declarative_base(self.orm)
             Base.metadata.create_all(engine)
             # Insert the data
-            insert_data(data, self.orm, session,
-                        low_memory=self.low_memory)
+            insert_data(data, self.orm, session, low_memory=self.low_memory)
 
     def run(self):
-        s3path = self.input().open('r').read()
+        s3path = self.input().open("r").read()
         data = self.curate_data(s3path)
         if isgeneratorfunction(self.curate_data):
             for chunk in data:
@@ -284,8 +315,8 @@ class CurateTask(ForceableTask, DapsTaskMixin):
         return self.output().touch()
 
     def output(self):
-        conf = CALLER_PKG.config['mysqldb']['mysqldb']
+        conf = CALLER_PKG.config["mysqldb"]["mysqldb"]
         conf["database"] = self.db_name
-        conf["table"] = '[daps-utils]'  # Just a dummy name
-        conf.pop('port', None)
+        conf["table"] = "[daps-utils]"  # Just a dummy name
+        conf.pop("port", None)
         return MySqlTarget(update_id=self.task_id, **conf)


### PR DESCRIPTION
Closes #101

This feature basically allows you to point your `CurateTask` to a previously finished flow, rather than rerunning flows each time. Because of the file reformatting... I'll point to the meat of the changes: it's lines 209-214. 

From the user's perspective, this adds in `stale_breadcrumb` as a parameter of `CurateTask`- which allows it to run the curation on "old" data pointed to by an old breadcrumb file. The main use cases are:

a) Finished prototyping a flow, and now want to transfer data to the database
b) Prototyping the curate step without rerunning the flow
c) The curate step has died due to a transient error, and you want to resume

In all cases you need to specify the exact flow path and orm (e.g. `enrich/skills.py` and `JobAdSkillLink`) - there will be unexpected behaviour if mixing breadcrumb files and orms that don't match. Potentially one might argue for this feature to select the latest breadcrumb, but I think that is a whole can of worms and could lead to bugs cropping up when other users are running flows.

For example in `enrich.py`:

```python
yield EnrichmentCurateTask(
    orm=JobAdSkillLink,
    flow_path="enrich/skills.py",
    file_prefix="skills",
    test=True,
    flow_tag="dev",
    stale_breadcrumb="s3://open-jobs-lake/metaflow/MetaflowTask______max_workers____enrich_skills_py_10eac5c805"
)
```

Would rerun the `MetaflowTask` with luigi id `MetaflowTask______max_workers____enrich_skills_py_10eac5c805`

Note that it adds the unfortunate possibility to run a curation on data that doesn't match the ORM