### PR TITLE
[111] detect project name from pyproject.toml

### DIFF
--- a/daps_utils/VERSION
+++ b/daps_utils/VERSION
@@ -1,1 +1,1 @@
-21.09.29.111_repo_name_robustness
+21.09.30.111_repo_name_robustness

--- a/daps_utils/VERSION
+++ b/daps_utils/VERSION
@@ -1,1 +1,1 @@
-21.08.26.107_apply_black
+21.09.28.111_repo_name_robustness

--- a/daps_utils/VERSION
+++ b/daps_utils/VERSION
@@ -1,1 +1,1 @@
-21.09.28.111_repo_name_robustness
+21.09.29.111_repo_name_robustness

--- a/daps_utils/requirements.txt
+++ b/daps_utils/requirements.txt
@@ -7,3 +7,4 @@ PyYAML==5.4.0
 gitpython==3.1.8
 SQLAlchemy==1.3.4
 sqlalchemy-utils==0.36.8
+toml==0.10.2

--- a/scripts/calver-init
+++ b/scripts/calver-init
@@ -74,7 +74,7 @@ function AddInstallFile(){
     echo 'set -e' >> install.sh        
     echo 'chmod +x .githooks/pre-commit' >> install.sh
     echo 'bash .githooks/pre-commit' >> install.sh
-    echo ln -sf "$PWD"/.githooks/pre-commit "$PWD"/.git/hooks/pre-commit >> install.sh
+    echo 'ln -sf "$PWD"/.githooks/pre-commit "$PWD"/.git/hooks/pre-commit' >> install.sh
     echo 'git config --local include.path ../.gitconfig' >> install.sh
     echo 'echo install.sh completed successfully' >> install.sh
     echo '################################################################' >> install.sh

--- a/scripts/calver-init
+++ b/scripts/calver-init
@@ -19,7 +19,7 @@ function _AssertFirstInit(){
 }
 
 function _EnsureShebang(){
-    if [ $(head -c 2 "$1") = "#!" ]; then
+    if [[ $(head -c 2 "$1") = "#!" ]]; then
         echo 'shebang already present'
     else
         echo 'prepending shebang'
@@ -43,9 +43,9 @@ function AddCalVerHook(){
     echo 'function incrementVersion {' >> .githooks/pre-commit
     echo '    CALVER=$(date +"%y.%m.%d")' >> .githooks/pre-commit
     echo '    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)' >> .githooks/pre-commit
-    echo '    PROJECT_ROOT=${PWD##*/}' >> .githooks/pre-commit
-    echo '    echo -n $CALVER.$CURRENT_BRANCH > ${PROJECT_ROOT}/VERSION' >> .githooks/pre-commit
-    echo '    git add ${PROJECT_ROOT}/VERSION' >> .githooks/pre-commit
+    echo '    PROJECT_NAME='"$1" >> .githooks/pre-commit
+    echo '    echo -n $CALVER.$CURRENT_BRANCH > ${PROJECT_NAME}/VERSION' >> .githooks/pre-commit
+    echo '    git add ${PROJECT_NAME}/VERSION' >> .githooks/pre-commit
     echo '}' >> .githooks/pre-commit
     echo 'incrementVersion' >> .githooks/pre-commit
     echo '################################################################' >> .githooks/pre-commit
@@ -55,7 +55,7 @@ function AddVersionMergeDriver(){
     # reference driver in .gitattributes
     _AssertFirstInit ".gitattributes"
     _AddHeader ".gitattributes"
-    echo "${PWD##*/}"/VERSION merge=always-ours >> .gitattributes
+    echo "$1"/VERSION merge=always-ours >> .gitattributes
     echo '################################################################' >> .gitattributes
     # define driver in .gitconfig
     _AssertFirstInit ".gitconfig"
@@ -74,7 +74,7 @@ function AddInstallFile(){
     echo 'set -e' >> install.sh        
     echo 'chmod +x .githooks/pre-commit' >> install.sh
     echo 'bash .githooks/pre-commit' >> install.sh
-    echo 'ln -sf $PWD/.githooks/pre-commit .git/hooks/pre-commit' >> install.sh
+    echo ln -sf "$1"/.githooks/pre-commit .git/hooks/pre-commit >> install.sh
     echo 'git config --local include.path ../.gitconfig' >> install.sh
     echo 'echo install.sh completed successfully' >> install.sh
     echo '################################################################' >> install.sh
@@ -98,11 +98,11 @@ if [ -z "$(git rev-list -n 1 --all)" ]; then
     exit 1
 fi
 
-# create subdir by the same name (e.g., ojd_daps/ojd_daps)
+calver_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+project_name=$("$calver_dir"/project_name.py .)
 # (this is where VERSION will live)
-mkdir -p "${PWD##*/}"
-
-AddCalVerHook
-AddVersionMergeDriver
-AddInstallFile
-echo "You can now inspect your Calendar Version from ${PWD##*/}/VERSION"
+mkdir -p "$project_name"
+AddCalVerHook "$project_name"
+AddVersionMergeDriver "$project_name"
+AddInstallFile "$project_name"
+echo You can now inspect your Calendar Version from "$project_name"/VERSION

--- a/scripts/calver-init
+++ b/scripts/calver-init
@@ -74,7 +74,7 @@ function AddInstallFile(){
     echo 'set -e' >> install.sh        
     echo 'chmod +x .githooks/pre-commit' >> install.sh
     echo 'bash .githooks/pre-commit' >> install.sh
-    echo ln -sf "$1"/.githooks/pre-commit .git/hooks/pre-commit >> install.sh
+    echo ln -sf "$PWD"/.githooks/pre-commit "$PWD"/.git/hooks/pre-commit >> install.sh
     echo 'git config --local include.path ../.gitconfig' >> install.sh
     echo 'echo install.sh completed successfully' >> install.sh
     echo '################################################################' >> install.sh
@@ -106,3 +106,5 @@ AddCalVerHook "$project_name"
 AddVersionMergeDriver "$project_name"
 AddInstallFile "$project_name"
 echo You can now inspect your Calendar Version from "$project_name"/VERSION
+echo You may wish to do:
+echo git add install.sh .githooks/pre-commit .gitconfig .gitattributes

--- a/scripts/project_name.py
+++ b/scripts/project_name.py
@@ -21,7 +21,8 @@ def _parent_dir(input_path):
 def _cli(input_str):
     input_path = _parent_dir(pathlib.Path(input_str).resolve())
     # one could have other places to look perhaps
-    if (toml_path := input_path / "pyproject.toml").exists():
+    toml_path = input_path / "pyproject.toml"
+    if toml_path.exists():
         # let's try to pull the name out of toml
         import toml
 

--- a/scripts/project_name.py
+++ b/scripts/project_name.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""project_name.py
+
+Work out the name of the python project for calver-init's pre-commit hook by looking
+for a name in pyproject.toml if it exists, or else deferring to the directory name.
+
+Usage: project_name.py dir
+
+Where dir is a path to the root path to the project."""
+import pathlib
+import sys
+
+
+def _parent_dir(input_path):
+    """Return parent directory for input path, if it isn't a dir already."""
+    while not input_path.is_dir():
+        input_path = input_path.parent
+    return input_path
+
+
+def _cli(input_str):
+    input_path = _parent_dir(pathlib.Path(input_str).resolve())
+    # one could have other places to look perhaps
+    if (toml_path := input_path / "pyproject.toml").exists():
+        # let's try to pull the name out of toml
+        import toml
+
+        pyproject = toml.load(toml_path)
+        try:
+            return pyproject["tool"]["poetry"]["name"]
+        except KeyError:
+            print(f"no tool.poetry.name field found in {toml_path}")
+    # let's revert to the directory name
+    return input_path.name
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        print("ERROR: unrecognised input\n")
+        print(__doc__)
+        sys.exit(1)
+    sys.stdout.write(_cli(sys.argv[-1]) + "\n")

--- a/scripts/test_project_name.sh
+++ b/scripts/test_project_name.sh
@@ -15,7 +15,7 @@ _FirstBranch() {
     git add testfile
     git commit -m "first commit"
     echo RUNNING CALVER-INIT
-    ../calver-init
+    calver-init
     git add install.sh .githooks/pre-commit .gitconfig .gitattributes
     git commit -m "calver init run"
     git checkout -b testbranch

--- a/scripts/test_project_name.sh
+++ b/scripts/test_project_name.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -x
+set -e
+
+# Run through a test project with calver-init and pyproject.toml naming
+# writes to CWD
+
+_TestVersion() {
+    [[ $(cat "$1"/VERSION | cut -d'.' -f 4) = "$2" ]]
+    return
+}
+
+_FirstBranch() {
+    git init
+    touch testfile
+    git add testfile
+    git commit -m "first commit"
+    echo RUNNING CALVER-INIT
+    ../calver-init
+    git add install.sh .githooks/pre-commit .gitconfig .gitattributes
+    git commit -m "calver init run"
+    git checkout -b testbranch
+    touch testfile2
+    git add testfile2
+    git commit -m "feature commit"
+    echo SHOULD BE testbranch
+    cat "$1"/VERSION
+    echo ""
+    _TestVersion "$1" "testbranch"
+    return
+}
+
+_SecondBranch() {
+    git checkout -b testbranch2
+    touch testfile3
+    git add testfile3
+    git commit -m "feature commit 2"
+    echo SHOULD BE testbranch2
+    cat "$1"/VERSION
+    echo ""
+    _TestVersion "$1" "testbranch2"
+    return
+}
+
+echo '*** DIR NAME TEST CASE ***'
+rm -Rf testrepo_dirname
+mkdir testrepo_dirname
+cd testrepo_dirname
+_FirstBranch "testrepo_dirname"
+_SecondBranch "testrepo_dirname"
+echo "TEST SUCCESS"
+cd ..
+
+echo '*** PYPROJECT NAME TEST CASE ***'
+rm -Rf testrepo_pyproject
+mkdir testrepo_pyproject
+cd testrepo_pyproject
+echo '[tool.poetry]' >> pyproject.toml
+echo 'name = "data_utils"' >> pyproject.toml
+_FirstBranch "data_utils"
+_SecondBranch "data_utils"
+echo "TEST SUCCESS"
+cd ..
+
+rm -Rf testrepo_dirname
+rm -Rf testrepo_pyproject
+echo "ALL TESTS SUCCEEDED"

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "scripts/metaflowtask-init",
         "scripts/calver-init",
         "scripts/project_name.py",
+        "scripts/test_project_name.sh",
     ],
     **common_kwargs,
 )

--- a/setup.py
+++ b/setup.py
@@ -7,35 +7,41 @@ os.environ["IN_SETUP"] = "1"  # noqa: E402
 from daps_utils import __version__, __basedir__  # noqa: E402
 
 
-version = ''.join(v for v in __version__ if (v.isnumeric() or v == '.'))
+version = "".join(v for v in __version__ if (v.isnumeric() or v == "."))
 
-with open(f'{__basedir__}/requirements.txt') as f:
+with open(f"{__basedir__}/requirements.txt") as f:
     required = f.read().splitlines()
 
-exclude = ['docs', 'tests*']
+exclude = ["docs", "tests*"]
 common_kwargs = dict(
     version=version,
-    license='MIT',
+    license="MIT",
     install_requires=required,
-    long_description=open('README.md').read(),
-    url='https://github.com/nestauk/daps_utils',
-    author='nesta',
-    author_email='software_development@nesta.org.uk',
-    maintainer='nesta',
-    maintainer_email='software_development@nesta.org.uk',
+    long_description=open("README.md").read(),
+    url="https://github.com/nestauk/daps_utils",
+    author="nesta",
+    author_email="software_development@nesta.org.uk",
+    maintainer="nesta",
+    maintainer_email="software_development@nesta.org.uk",
     classifiers=[
-        'Development Status :: 1 - Planning',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 1 - Planning",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.7",
     ],
-    python_requires='>=3.7',
+    python_requires=">=3.7",
     include_package_data=True,
 )
 
-setup(name='daps_utils',
-      packages=find_namespace_packages(where='.', exclude=exclude),
-      scripts=['scripts/metaflowtask-init', 'scripts/calver-init'],
-      **common_kwargs)
+setup(
+    name="daps_utils",
+    packages=find_namespace_packages(where=".", exclude=exclude),
+    scripts=[
+        "scripts/metaflowtask-init",
+        "scripts/calver-init",
+        "scripts/project_name.py",
+    ],
+    **common_kwargs,
+)


### PR DESCRIPTION
Closes #111 

Adds support for cases where the repo name isn't the project name.

Please note test in `scripts/test_project_name.sh`. Currently this gets added to the user path in `setup.py` which is a bit inelegant but necessary to keep the CI happy. Perhaps the script tests could be improved in a separate issue.